### PR TITLE
Split signrawtransaction into wallet and non-wallet RPC calls

### DIFF
--- a/src/BitcoinLib/RPC/Specifications/RpcMethods.cs
+++ b/src/BitcoinLib/RPC/Specifications/RpcMethods.cs
@@ -61,6 +61,8 @@ namespace BitcoinLib.RPC.Specifications
         getrawtransaction,
         sendrawtransaction,
         signrawtransaction,
+        signrawtransactionwithkey,
+        signrawtransactionwithwallet,
         sighashtype,
 
         //== Util ==

--- a/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithKeyInput.cs
+++ b/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithKeyInput.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using Newtonsoft.Json;
+
+namespace BitcoinLib.Requests.SignRawTransaction
+{
+    public class SignRawTransactionWithKeyInput
+    {
+        [JsonProperty(PropertyName = "txid", Order = 0)]
+        public string TxId { get; set; }
+
+        [JsonProperty(PropertyName = "vout", Order = 1)]
+        public int Vout { get; set; }
+
+        [JsonProperty(PropertyName = "scriptPubKey", Order = 2)]
+        public string ScriptPubKey { get; set; }
+
+        [JsonProperty(PropertyName = "redeemScript", Order = 3)]
+        public string RedeemScript { get; set; }
+    }
+}

--- a/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithKeyRequest.cs
+++ b/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithKeyRequest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using System.Collections.Generic;
+
+namespace BitcoinLib.Requests.SignRawTransaction
+{
+    public class SignRawTransactionWithKeyRequest
+    {
+        public SignRawTransactionWithKeyRequest(string rawTransactionHex, string sigHashType = "ALL")
+        {
+            RawTransactionHex = rawTransactionHex;
+            PrivateKeys = new List<string>();
+            Inputs = new List<SignRawTransactionWithKeyInput>();
+            SigHashType = sigHashType;
+        }
+
+        public string RawTransactionHex { get; set; }
+        public List<string> PrivateKeys { get; set; }
+        public List<SignRawTransactionWithKeyInput> Inputs { get; set; }
+        public string SigHashType { get; set; }
+
+        public void AddKey(string privateKey)
+        {
+            PrivateKeys.Add(privateKey);
+        }
+
+        public void AddInput(string txId, int vout, string scriptPubKey, string redeemScript)
+        {
+            Inputs.Add(new SignRawTransactionWithKeyInput
+            {
+                TxId = txId,
+                Vout = vout,
+                ScriptPubKey = scriptPubKey,
+                RedeemScript = redeemScript
+            });
+        }
+
+        public void AddInput(SignRawTransactionWithKeyInput input)
+        {
+            Inputs.Add(input);
+        }
+    }
+}

--- a/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithWalletInput.cs
+++ b/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithWalletInput.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using Newtonsoft.Json;
+
+namespace BitcoinLib.Requests.SignRawTransaction
+{
+    public class SignRawTransactionWithWalletInput
+    {
+        [JsonProperty(PropertyName = "txid", Order = 0)]
+        public string TxId { get; set; }
+
+        [JsonProperty(PropertyName = "vout", Order = 1)]
+        public int Vout { get; set; }
+
+        [JsonProperty(PropertyName = "scriptPubKey", Order = 2)]
+        public string ScriptPubKey { get; set; }
+
+        [JsonProperty(PropertyName = "redeemScript", Order = 3)]
+        public string RedeemScript { get; set; }
+    }
+}

--- a/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithWalletRequest.cs
+++ b/src/BitcoinLib/Requests/SignRawTransaction/SignRawTransactionWithWalletRequest.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+using System.Collections.Generic;
+
+namespace BitcoinLib.Requests.SignRawTransaction
+{
+    public class SignRawTransactionWithWalletRequest
+    {
+        public SignRawTransactionWithWalletRequest(string rawTransactionHex, string sigHashType = "ALL")
+        {
+            RawTransactionHex = rawTransactionHex;
+            Inputs = new List<SignRawTransactionWithWalletInput>();
+            SigHashType = sigHashType;
+        }
+
+        public string RawTransactionHex { get; set; }
+        public List<SignRawTransactionWithWalletInput> Inputs { get; set; }
+        public string SigHashType { get; set; }
+
+        public void AddInput(string txId, int vout, string scriptPubKey, string redeemScript)
+        {
+            Inputs.Add(new SignRawTransactionWithWalletInput
+            {
+                TxId = txId,
+                Vout = vout,
+                ScriptPubKey = scriptPubKey,
+                RedeemScript = redeemScript
+            });
+        }
+
+        public void AddInput(SignRawTransactionWithWalletInput input)
+        {
+            Inputs.Add(input);
+        }
+    }
+}

--- a/src/BitcoinLib/Responses/SignRawTransactionWithKeyResponse.cs
+++ b/src/BitcoinLib/Responses/SignRawTransactionWithKeyResponse.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+namespace BitcoinLib.Responses
+{
+    public class SignRawTransactionWithKeyResponse
+    {
+        public string Hex { get; set; }
+        public bool Complete { get; set; }
+    }
+}

--- a/src/BitcoinLib/Responses/SignRawTransactionWithWalletResponse.cs
+++ b/src/BitcoinLib/Responses/SignRawTransactionWithWalletResponse.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) 2014 - 2016 George Kimionis
+// See the accompanying file LICENSE for the Software License Aggrement
+
+namespace BitcoinLib.Responses
+{
+    public class SignRawTransactionWithWalletResponse
+    {
+        public string Hex { get; set; }
+        public bool Complete { get; set; }
+    }
+}

--- a/src/BitcoinLib/Services/RpcServices/RpcService/IRpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/IRpcService.cs
@@ -82,6 +82,8 @@ namespace BitcoinLib.Services.RpcServices.RpcService
         GetRawTransactionResponse GetRawTransaction(string txId, int verbose = 0);
         string SendRawTransaction(string rawTransactionHexString, bool? allowHighFees = false);
         SignRawTransactionResponse SignRawTransaction(SignRawTransactionRequest signRawTransactionRequest);
+        SignRawTransactionWithKeyResponse SignRawTransactionWithKey(SignRawTransactionWithKeyRequest signRawTransactionWithKeyRequest);
+        SignRawTransactionWithWalletResponse SignRawTransactionWithWallet(SignRawTransactionWithWalletRequest signRawTransactionWithWalletRequest);
         GetFundRawTransactionResponse GetFundRawTransaction(string rawTransactionHex);
 
         #endregion

--- a/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
@@ -654,6 +654,49 @@ namespace BitcoinLib.Services
             return _rpcConnector.MakeRequest<SignRawTransactionResponse>(RpcMethods.signrawtransaction, request.RawTransactionHex, request.Inputs, request.PrivateKeys, request.SigHashType);
         }
 
+        public SignRawTransactionWithKeyResponse SignRawTransactionWithKey(SignRawTransactionWithKeyRequest request)
+        {
+            #region default values
+
+            if (request.PrivateKeys.Count == 0)
+            {
+                request.PrivateKeys = null;
+            }
+
+            if (request.Inputs.Count == 0)
+            {
+                request.Inputs = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(request.SigHashType))
+            {
+                request.SigHashType = SigHashType.All;
+            }
+
+            #endregion
+
+            return _rpcConnector.MakeRequest<SignRawTransactionWithKeyResponse>(RpcMethods.signrawtransactionwithkey, request.RawTransactionHex, request.PrivateKeys, request.Inputs, request.SigHashType);
+        }
+
+        public SignRawTransactionWithWalletResponse SignRawTransactionWithWallet(SignRawTransactionWithWalletRequest request)
+        {
+            #region default values
+
+            if (request.Inputs.Count == 0)
+            {
+                request.Inputs = null;
+            }
+
+            if (string.IsNullOrWhiteSpace(request.SigHashType))
+            {
+                request.SigHashType = SigHashType.All;
+            }
+
+            #endregion
+
+            return _rpcConnector.MakeRequest<SignRawTransactionWithWalletResponse>(RpcMethods.signrawtransactionwithwallet, request.RawTransactionHex, request.Inputs, request.SigHashType);
+        }
+
         public GetFundRawTransactionResponse GetFundRawTransaction(string rawTransactionHex)
         {
             return _rpcConnector.MakeRequest<GetFundRawTransactionResponse>(RpcMethods.fundrawtransaction, rawTransactionHex);


### PR DESCRIPTION
As per the [low-level RPC changes](https://bitcoincore.org/en/releases/0.17.0/#low-level-rpc-changes) introduced in Bitcoin Core v0.17:

>signrawtransaction is deprecated and will be fully removed in v0.18. To use signrawtransaction in v0.17, restart bitcoind with -deprecatedrpc=signrawtransaction
Projects should transition to using signrawtransactionwithkey and signrawtransactionwithwallet before upgrading to v0.18.

/cc @GeorgeKimionis 