### PR TITLE
Support for BitcoinCash, Colx and improved Dash support (tested with 0.13 as well)

### DIFF
--- a/demo/App.config
+++ b/demo/App.config
@@ -20,6 +20,14 @@
     <add key="Bitcoin_RpcPassword" value="MyRpcPassword" />
     <!-- Bitcoin settings end -->
 
+	<!-- BitcoinCash settings start (usually pointing to a different server, can't run on same ports as bitcoin on same machine) -->
+	<add key="BitcoinCash_DaemonUrl" value="http://localhost:8332"/>
+	<add key="BitcoinCash_DaemonUrl_Testnet" value="http://localhost:8332"/>
+	<add key="BitcoinCash_WalletPassword" value="MyWalletPassword"/>
+	<add key="BitcoinCash_RpcUsername" value="MyRpcUsername"/>
+	<add key="BitcoinCash_RpcPassword" value="MyRpcPassword"/>
+    <!-- BitcoinCash settings end -->
+	
     <!-- Litecoin settings start -->
     <add key="Litecoin_DaemonUrl" value="http://localhost:9332" />
     <add key="Litecoin_DaemonUrl_Testnet" value="http://localhost:19332" />

--- a/demo/App.config
+++ b/demo/App.config
@@ -84,6 +84,14 @@
     <add key="Dallar_RpcPassword" value="MyRpcPassword" />
     <!-- Dallar settings end -->
 
+    <!-- Colx settings start -->
+    <add key="Colx_DaemonUrl" value="http://localhost:51473" />
+    <add key="Colx_DaemonUrl_Testnet" value="http://localhost:51472" />
+    <add key="Colx_WalletPassword" value="MyWalletPassword" />
+    <add key="Colx_RpcUsername" value="MyRpcUsername" />
+    <add key="Colx_RpcPassword" value="MyRpcPassword" />
+    <!-- Colx settings end -->
+
     <!-- Demo client settings start -->
     <add key="ExtractMyPrivateKeys" value="false" />
     <!-- Demo client settings end -->

--- a/src/BitcoinLib/CoinParameters/Base/CoinParameters.cs
+++ b/src/BitcoinLib/CoinParameters/Base/CoinParameters.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using BitcoinLib.Auxiliary;
 using BitcoinLib.Services.Coins.Base;
 using BitcoinLib.Services.Coins.Bitcoin;
+using BitcoinLib.Services.Coins.BitcoinCash;
+using BitcoinLib.Services.Coins.Colx;
 using BitcoinLib.Services.Coins.Cryptocoin;
 using BitcoinLib.Services.Coins.Dallar;
 using BitcoinLib.Services.Coins.Dash;
@@ -68,10 +70,47 @@ namespace BitcoinLib.Services
                     Console.WriteLine("[WARNING] The wallet password is either null or empty");
                     Console.ResetColor();
                 }
+								
+								#region BitcoinCash
+								if (coinService is BitcoinCashService)
+								{
+									if (!IgnoreConfigFiles)
+									{
+										DaemonUrl = ConfigurationManager.AppSettings.Get("BitcoinCash_DaemonUrl");
+										DaemonUrlTestnet = ConfigurationManager.AppSettings.Get("BitcoinCash_DaemonUrl_Testnet");
+										RpcUsername = ConfigurationManager.AppSettings.Get("BitcoinCash_RpcUsername");
+										RpcPassword = ConfigurationManager.AppSettings.Get("BitcoinCash_RpcPassword");
+										WalletPassword = ConfigurationManager.AppSettings.Get("BitcoinCash_WalletPassword");
+									}
+					
+									CoinShortName = "BCH";
+									CoinLongName = "BitcoinCash";
+									IsoCurrencyCode = "BCH";
 
-                #region Bitcoin
+									TransactionSizeBytesContributedByEachInput = 148;
+									TransactionSizeBytesContributedByEachOutput = 34;
+									TransactionSizeFixedExtraSizeInBytes = 10;
 
-                if (coinService is BitcoinService)
+									FreeTransactionMaximumSizeInBytes = 1000;
+									FreeTransactionMinimumOutputAmountInCoins = 0.01M;
+									FreeTransactionMinimumPriority = 57600000;
+									FeePerThousandBytesInCoins = 0.0001M;
+									MinimumTransactionFeeInCoins = 0.0001M;
+									MinimumNonDustTransactionAmountInCoins = 0.0000543M;
+
+									TotalCoinSupplyInCoins = 21000000;
+									EstimatedBlockGenerationTimeInMinutes = 10;
+									BlocksHighestPriorityTransactionsReservedSizeInBytes = 50000;
+
+									BaseUnitName = "Satoshi";
+									BaseUnitsPerCoin = 100000000;
+									CoinsPerBaseUnit = 0.00000001M;
+								}
+								#endregion
+
+								#region Bitcoin
+
+								else if (coinService is BitcoinService)
                 {
                     if (!IgnoreConfigFiles)
                     {
@@ -372,6 +411,44 @@ namespace BitcoinLib.Services
                 }
 
                 #endregion
+								
+								#region Colx
+
+								else if (coinService is ColxService)
+								{
+									if (!IgnoreConfigFiles)
+									{
+										DaemonUrl = ConfigurationManager.AppSettings.Get("Colx_DaemonUrl");
+										DaemonUrlTestnet = ConfigurationManager.AppSettings.Get("Colx_DaemonUrl_Testnet");
+										RpcUsername = ConfigurationManager.AppSettings.Get("Colx_RpcUsername");
+										RpcPassword = ConfigurationManager.AppSettings.Get("Colx_RpcPassword");
+										WalletPassword = ConfigurationManager.AppSettings.Get("Colx_WalletPassword");
+									}
+									CoinShortName = "COLX";
+									CoinLongName = "ColossusXT Coin";
+									IsoCurrencyCode = "COLX";
+
+									TransactionSizeBytesContributedByEachInput = 148;
+									TransactionSizeBytesContributedByEachOutput = 34;
+									TransactionSizeFixedExtraSizeInBytes = 10;
+
+									FreeTransactionMaximumSizeInBytes = 1000;
+									FreeTransactionMinimumOutputAmountInCoins = 0.0001M;
+									FreeTransactionMinimumPriority = 57600000;
+									FeePerThousandBytesInCoins = 0.0001M;
+									MinimumTransactionFeeInCoins = 0.001M;
+									MinimumNonDustTransactionAmountInCoins = 0.0000543M;
+
+									TotalCoinSupplyInCoins = 18900000;
+									EstimatedBlockGenerationTimeInMinutes = 2.7;
+									BlocksHighestPriorityTransactionsReservedSizeInBytes = 50000;
+
+									BaseUnitName = "ucolx";
+									BaseUnitsPerCoin = 100000000;
+									CoinsPerBaseUnit = 0.00000001M;
+								}
+
+								#endregion
 
                 #region Agnostic coin (cryptocoin)
 

--- a/src/BitcoinLib/CoinParameters/Colx/ColxConstants.cs
+++ b/src/BitcoinLib/CoinParameters/Colx/ColxConstants.cs
@@ -1,0 +1,14 @@
+﻿using BitcoinLib.CoinParameters.Base;
+
+namespace BitcoinLib.CoinParameters.Colx
+{
+    public static class ColxConstants
+    {
+        public sealed class Constants : CoinConstants<Constants>
+        {
+            public readonly ushort CoinReleaseHalfsEveryXInYears = 7;
+            public readonly ushort DifficultyIncreasesEveryXInBlocks = 34560;
+            public readonly string Symbol = "COLX";
+        }
+    }
+}

--- a/src/BitcoinLib/CoinParameters/Colx/IColxConstants.cs
+++ b/src/BitcoinLib/CoinParameters/Colx/IColxConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace BitcoinLib.CoinParameters.Colx
+{
+	public interface IColxConstants
+	{
+		ColxConstants.Constants Constants { get; }
+	}
+}

--- a/src/BitcoinLib/RPC/Specifications/RpcMethods.cs
+++ b/src/BitcoinLib/RPC/Specifications/RpcMethods.cs
@@ -123,6 +123,12 @@ namespace BitcoinLib.RPC.Specifications
         signmessage,
         walletlock,
         walletpassphrase,
-        walletpassphrasechange
+        walletpassphrasechange,
+				//2018-01-20: added Dash privatesend mixing support
+				privatesend,
+				//2018-03-02: added getaddressbalance (needs addressindex = 1 in dash.conf)
+				getaddressbalance,
+				//2018-07-23: Masternode support, usually list command is used
+				masternode
     }
 }

--- a/src/BitcoinLib/Services/Coins/Bitcoin/BitcoinService.cs
+++ b/src/BitcoinLib/Services/Coins/Bitcoin/BitcoinService.cs
@@ -2,6 +2,7 @@
 // See the accompanying file LICENSE for the Software License Aggrement
 
 using BitcoinLib.CoinParameters.Bitcoin;
+using BitcoinLib.RPC.Specifications;
 
 namespace BitcoinLib.Services.Coins.Bitcoin
 {
@@ -22,5 +23,17 @@ namespace BitcoinLib.Services.Coins.Bitcoin
         }
 
         public BitcoinConstants.Constants Constants => BitcoinConstants.Constants.Instance;
+				
+				public string SendToAddress(string bitcoinAddress, decimal amount, string comment, string commentTo, bool subtractFeeFromAmount, bool allowReplaceByFee)
+				{
+					return _rpcConnector.MakeRequest<string>(RpcMethods.sendtoaddress, bitcoinAddress, amount, comment, commentTo, subtractFeeFromAmount, allowReplaceByFee);
+				}
+
+				public string GetNewAddress(string account = "", string addressType = "")
+				{
+					return string.IsNullOrWhiteSpace(account)
+						? _rpcConnector.MakeRequest<string>(RpcMethods.getnewaddress)
+						: _rpcConnector.MakeRequest<string>(RpcMethods.getnewaddress, account, addressType);
+				}
     }
 }

--- a/src/BitcoinLib/Services/Coins/BitcoinCash/BitcoinCashService.cs
+++ b/src/BitcoinLib/Services/Coins/BitcoinCash/BitcoinCashService.cs
@@ -1,0 +1,18 @@
+﻿using BitcoinLib.CoinParameters.Bitcoin;
+using BitcoinLib.Services.Coins.Bitcoin;
+
+namespace BitcoinLib.Services.Coins.BitcoinCash
+{
+	public class BitcoinCashService : CoinService, IBitcoinService
+	{
+		public BitcoinCashService(bool useTestnet = false) : base(useTestnet)
+		{
+		}
+
+		public BitcoinCashService(string daemonUrl, string rpcUsername, string rpcPassword, string walletPassword, short rpcRequestTimeoutInSeconds) : base(daemonUrl, rpcUsername, rpcPassword, walletPassword, rpcRequestTimeoutInSeconds)
+		{
+		}
+
+		public BitcoinConstants.Constants Constants => BitcoinConstants.Constants.Instance;
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Colx/ColxService.cs
+++ b/src/BitcoinLib/Services/Coins/Colx/ColxService.cs
@@ -1,0 +1,23 @@
+﻿using BitcoinLib.CoinParameters.Colx;
+using BitcoinLib.Services.Coins.Bitcoin;
+using BitcoinLib.Services.Coins.Dash;
+
+namespace BitcoinLib.Services.Coins.Colx
+{
+	/// <summary>
+	/// Mostly the same functionality as <see cref="BitcoinService"/>.
+	/// </summary>
+	public class ColxService : DashService, IColxService
+	{
+		public ColxService(bool useTestnet = false) : base(useTestnet) { }
+
+		public ColxService(string daemonUrl, string rpcUsername, string rpcPassword,
+			string walletPassword) : base(daemonUrl, rpcUsername, rpcPassword, walletPassword) { }
+
+		public ColxService(string daemonUrl, string rpcUsername, string rpcPassword,
+			string walletPassword, short rpcRequestTimeoutInSeconds) : base(daemonUrl, rpcUsername,
+			rpcPassword, walletPassword, rpcRequestTimeoutInSeconds) { }
+		
+		public new ColxConstants.Constants Constants => ColxConstants.Constants.Instance;
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Colx/IColxService.cs
+++ b/src/BitcoinLib/Services/Coins/Colx/IColxService.cs
@@ -1,0 +1,9 @@
+﻿using BitcoinLib.CoinParameters.Colx;
+using BitcoinLib.Services.Coins.Base;
+
+namespace BitcoinLib.Services.Coins.Colx
+{
+    public interface IColxService : ICoinService, IColxConstants
+    {
+    }
+}

--- a/src/BitcoinLib/Services/Coins/Dash/AddressBalanceRequest.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/AddressBalanceRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace BitcoinLib.Services.Coins.Dash
+{
+	public class AddressBalanceRequest
+	{
+		[JsonProperty("addresses")]
+		public List<string> Addresses { get; set; }
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Dash/AddressBalanceResponse.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/AddressBalanceResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace BitcoinLib.Services.Coins.Dash
+{
+	public class AddressBalanceResponse
+	{
+		public long Balance { get; set; }
+		public long Received { get; set; }
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Dash/DashService.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/DashService.cs
@@ -1,33 +1,91 @@
-﻿using BitcoinLib.CoinParameters.Dash;
+﻿using System.Collections.Generic;
+using System.Linq;
+using BitcoinLib.CoinParameters.Dash;
+using BitcoinLib.Requests.SignRawTransaction;
 using BitcoinLib.RPC.Specifications;
+using BitcoinLib.Services.Coins.Bitcoin;
+using Newtonsoft.Json.Linq;
 
 namespace BitcoinLib.Services.Coins.Dash
 {
-    public class DashService : CoinService, IDashService
-    {
-        public DashService(bool useTestnet = false) : base(useTestnet)
-        {
-        }
+	/// <summary>
+	/// Mostly the same functionality as <see cref="BitcoinService"/>, just adds a bunch more features
+	/// for handling InstantSend and PrivateSend, plus better raw tx generation support.
+	/// </summary>
+	public class DashService : CoinService, IDashService
+	{
+		public DashService(bool useTestnet = false) : base(useTestnet) { }
 
-        public DashService(string daemonUrl, string rpcUsername, string rpcPassword, string walletPassword)
-            : base(daemonUrl, rpcUsername, rpcPassword, walletPassword)
-        {
-        }
+		public DashService(string daemonUrl, string rpcUsername, string rpcPassword,
+			string walletPassword) : base(daemonUrl, rpcUsername, rpcPassword, walletPassword) { }
 
-        public DashService(string daemonUrl, string rpcUsername, string rpcPassword, string walletPassword,
-            short rpcRequestTimeoutInSeconds)
-            : base(daemonUrl, rpcUsername, rpcPassword, walletPassword, rpcRequestTimeoutInSeconds)
-        {
-        }
+		public DashService(string daemonUrl, string rpcUsername, string rpcPassword,
+			string walletPassword, short rpcRequestTimeoutInSeconds) : base(daemonUrl, rpcUsername,
+			rpcPassword, walletPassword, rpcRequestTimeoutInSeconds) { }
+		
+		/// <summary>
+		/// Adds InstantSend and PrivateSend to SendToAddress from our wallet.
+		/// </summary>
+		/// <inheritdoc />
+		public string SendToAddress(string dashAddress, decimal amount, string comment = null,
+			string commentTo = null, bool subtractFeeFromAmount = false, bool useInstantSend = false,
+			bool usePrivateSend = false)
+			=> _rpcConnector.MakeRequest<string>(RpcMethods.sendtoaddress, dashAddress, amount,
+				comment, commentTo, subtractFeeFromAmount, useInstantSend, usePrivateSend);
 
-        /// <inheritdoc />
-        public string SendToAddress(string dashAddress, decimal amount, string comment = null, string commentTo = null,
-            bool subtractFeeFromAmount = false, bool useInstantSend = false, bool usePrivateSend = false)
-        {
-            return _rpcConnector.MakeRequest<string>(RpcMethods.sendtoaddress, dashAddress, amount, comment, commentTo,
-                subtractFeeFromAmount, useInstantSend, usePrivateSend);
-        }
+		/// <summary>
+		/// Adds InstantSend support to SendRawTransaction
+		/// </summary>
+		public string SendRawTransaction(string rawTransactionHexString, bool allowHighFees,
+			bool useInstantSend)
+			=> _rpcConnector.MakeRequest<string>(RpcMethods.sendrawtransaction, rawTransactionHexString,
+				allowHighFees, useInstantSend);
+		
+		public SignRawTransactionWithErrorResponse SignRawTransactionWithErrorSupport(
+			SignRawTransactionRequest request)
+		{
+			if (request.Inputs.Count == 0)
+				request.Inputs = null;
+			if (string.IsNullOrWhiteSpace(request.SigHashType))
+				request.SigHashType = "ALL";
+			if (request.PrivateKeys.Count == 0)
+				request.PrivateKeys = null;
+			return _rpcConnector.MakeRequest<SignRawTransactionWithErrorResponse>(
+				RpcMethods.signrawtransaction, request.RawTransactionHex, request.Inputs,
+				request.PrivateKeys, request.SigHashType);
+		}
 
-        public DashConstants.Constants Constants => DashConstants.Constants.Instance;
-    }
+		/// <summary>
+		/// privatesend "command"
+		/// Arguments:
+		/// 1. "command"        (string or set of strings, required) The command to execute
+		/// Available commands:
+		/// start       - Start mixing
+		/// stop        - Stop mixing
+		/// reset       - Reset mixing
+		/// </summary>
+		public string SendPrivateSendCommand(string command)
+			=> _rpcConnector.MakeRequest<string>(RpcMethods.privatesend, command);
+
+		public AddressBalanceResponse GetAddressBalance(AddressBalanceRequest addresses)
+			=> _rpcConnector.MakeRequest<AddressBalanceResponse>(RpcMethods.getaddressbalance, addresses);
+
+		/// <summary>
+		/// Extends unspend result to show ps_rounds to check for available mixed PrivateSend amount.
+		/// </summary>
+		public List<ListUnspentDashResponse> ListUnspentPrivateSend()
+			=> _rpcConnector.MakeRequest<List<ListUnspentDashResponse>>(RpcMethods.listunspent,
+				1, 9999999, new List<string>());
+
+		public DashConstants.Constants Constants => DashConstants.Constants.Instance;
+
+		public List<MasternodeResponse> MasternodeList()
+		{
+			var response = _rpcConnector.MakeRequest<JObject>(RpcMethods.masternode, "list");
+			var result = new List<MasternodeResponse>();
+			foreach (var data in response)
+				result.Add(data.Value.ToObject<MasternodeResponse>());
+			return result;
+		}
+	}
 }

--- a/src/BitcoinLib/Services/Coins/Dash/ListUnspentDashResponse.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/ListUnspentDashResponse.cs
@@ -1,0 +1,9 @@
+﻿using BitcoinLib.Responses;
+
+namespace BitcoinLib.Services.Coins.Dash
+{
+	public class ListUnspentDashResponse : ListUnspentResponse
+	{
+		public decimal Ps_Rounds { get; set; }
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Dash/MasternodeListResponse.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/MasternodeListResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace BitcoinLib.Services.Coins.Dash
+{
+	public class MasternodeResponse
+	{
+		public string Address { get; set; }
+		public string Payee { get; set; }
+		public string Status { get; set; }
+		public int Protocol { get; set; }
+		public int LastSeen { get; set; }
+		public int ActiveSeconds { get; set; }
+		public int LastPaidTime { get; set; }
+		public int LastPaidBlock { get; set; }
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Dash/SignRawTransactionError.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/SignRawTransactionError.cs
@@ -1,0 +1,11 @@
+﻿namespace BitcoinLib.Services.Coins.Dash
+{
+	public class SignRawTransactionError
+	{
+		public string Txid { get; set; }
+		public int Vout { get; set; }
+		public string ScriptSig { get; set; }
+		public long Sequence { get; set; }
+		public string Error { get; set; }
+	}
+}

--- a/src/BitcoinLib/Services/Coins/Dash/SignRawTransactionWithErrorResponse.cs
+++ b/src/BitcoinLib/Services/Coins/Dash/SignRawTransactionWithErrorResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using BitcoinLib.Responses;
+
+namespace BitcoinLib.Services.Coins.Dash
+{
+	public class SignRawTransactionWithErrorResponse : SignRawTransactionResponse
+	{
+		public List<SignRawTransactionError> Errors { get; set; }
+	}
+}

--- a/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using BitcoinLib.Requests.AddNode;
 using BitcoinLib.Requests.CreateRawTransaction;
@@ -75,6 +76,23 @@ namespace BitcoinLib.Services
         {
             return _rpcConnector.MakeRequest<string>(RpcMethods.createrawtransaction, rawTransaction.Inputs, rawTransaction.Outputs);
         }
+
+				/// <summary>
+				/// Lower level CreateRawTransaction RPC request to allow other kinds of output, e.g.
+				/// "data":"text" for OP_RETURN Null Data for chat on the blockchain. CreateRawTransaction(
+				/// CreateRawTransactionRequest) only allows for "receiver":amount outputs.
+				/// </summary>
+				public string CreateRawTransaction(IList<CreateRawTransactionInput> inputs,
+					string chatHex, string receiverAddress, decimal receiverAmount)
+				{
+					// Must be a dictionary to become an json object, an array will fail on the RPC side
+					var outputs = new Dictionary<string, string>
+					{
+						{ "data", chatHex },
+						{ receiverAddress, receiverAmount.ToString(NumberFormatInfo.InvariantInfo) }
+					};
+					return _rpcConnector.MakeRequest<string>(RpcMethods.createrawtransaction, inputs, outputs);
+				}
 
         public DecodeRawTransactionResponse DecodeRawTransaction(string rawTransactionHexString)
         {


### PR DESCRIPTION
Added BitcoinCash support (to run side by side with Bitcoin)
Added Colx Support
Tested with Dash 0.13, which was released this week, not yet added support for new transaction types (not really needed yet). Also added ListUnspendDashResponse, AddressBalanceRequest and AddressBalanceResponse, ListUnspendDashResponse, MasternodeListREsponse, SignRawTransactionError and SignRawTransactionWithErrorResponse to support many more usecases (most of these can be used for Bitcoin and especially Dash forks too, e.g. CreateRawTransaction to generate OP_RETURN text messages in the blockchain works for any Bitcoin based blockchain).