### PR TITLE
Add Weight, MedianTime, and Verbosity in GetBlockResponse

### DIFF
--- a/src/BitcoinLib/Responses/GetBlockResponse.cs
+++ b/src/BitcoinLib/Responses/GetBlockResponse.cs
@@ -17,6 +17,7 @@ namespace BitcoinLib.Responses
         public int Confirmations { get; set; }
         public int Size { get; set; }
         public int Height { get; set; }
+        public int Weight { get; set; }
         public int Version { get; set; }
         public string MerkleRoot { get; set; }
         public double Difficulty { get; set; }

--- a/src/BitcoinLib/Responses/GetBlockResponse.cs
+++ b/src/BitcoinLib/Responses/GetBlockResponse.cs
@@ -26,6 +26,7 @@ namespace BitcoinLib.Responses
         public string NextBlockHash { get; set; }
         public string Bits { get; set; }
         public int Time { get; set; }
+        public int MedianTime { get; set; }
         public string Nonce { get; set; }
     }
 }

--- a/src/BitcoinLib/Responses/GetBlockResponse.cs
+++ b/src/BitcoinLib/Responses/GetBlockResponse.cs
@@ -1,18 +1,13 @@
 ﻿// Copyright (c) 2014 - 2016 George Kimionis
 // See the accompanying file LICENSE for the Software License Aggrement
 
+using BitcoinLib.Responses.SharedComponents;
 using System.Collections.Generic;
 
 namespace BitcoinLib.Responses
 {
-    public class GetBlockResponse
+    public abstract class GetBlockResponseBase
     {
-        public GetBlockResponse()
-        {
-            Tx = new List<string>();
-        }
-
-        public List<string> Tx { get; set; }
         public string Hash { get; set; }
         public int Confirmations { get; set; }
         public int Size { get; set; }
@@ -29,4 +24,38 @@ namespace BitcoinLib.Responses
         public int MedianTime { get; set; }
         public string Nonce { get; set; }
     }
+
+    public class GetBlockResponse : GetBlockResponseBase
+    {
+        public GetBlockResponse()
+        {
+            Tx = new List<string>();
+        }
+
+        public List<string> Tx { get; set; }
+    }
+
+    public class GetBlockResponseVerbose : GetBlockResponseBase
+    {
+        public GetBlockResponseVerbose()
+        {
+            Tx = new List<IncludedTransaction>();
+        }
+
+        public List<IncludedTransaction> Tx { get; set; }
+    }
+
+    public class IncludedTransaction
+    {
+        public string Hex { get; set; }
+        public long Version { get; set; }
+        public uint LockTime { get; set; }
+        public List<Vin> Vin { get; set; }
+        public List<Vout> Vout { get; set; }
+        public string TxId { get; set; }
+        public int Size { get; set; }
+        public int VSize { get; set; }
+        public int Weight { get; set; }
+    }
+
 }

--- a/src/BitcoinLib/Services/RpcServices/RpcService/IRpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/IRpcService.cs
@@ -15,6 +15,7 @@ namespace BitcoinLib.Services.RpcServices.RpcService
 
         string GetBestBlockHash();
         GetBlockResponse GetBlock(string hash, bool verbose = true);
+        GetBlockResponseVerbose GetBlock(string hash, int verbosity);
         GetBlockchainInfoResponse GetBlockchainInfo();
         uint GetBlockCount();
         string GetBlockHash(long index);

--- a/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
+++ b/src/BitcoinLib/Services/RpcServices/RpcService/RpcService.cs
@@ -178,6 +178,16 @@ namespace BitcoinLib.Services
             return _rpcConnector.MakeRequest<GetBlockResponse>(RpcMethods.getblock, hash, verbose);
         }
 
+        public GetBlockResponseVerbose GetBlock(string hash, int verbosity)
+        {
+            if (verbosity < 2)
+            {
+                throw new ArgumentException("This method is only available for verbosity levels above 1. Please use method where 2nd argument is a boolean instead.");
+            }
+
+            return _rpcConnector.MakeRequest<GetBlockResponseVerbose>(RpcMethods.getblock, hash, verbosity);
+        }
+
         public GetBlockchainInfoResponse GetBlockchainInfo()
         {
             return _rpcConnector.MakeRequest<GetBlockchainInfoResponse>(RpcMethods.getblockchaininfo);


### PR DESCRIPTION
This commit adds Weight as a parameter to GetBlockResponse
thus allowing the user to get the weight of a specific block.

Weight was introduced along with the segwit softfork as a new
measure for block size.

Tests against my own test network node has been performed.

This pull request closes #107.