### PR TITLE
Change type of NetworkHashPS to double

### DIFF
--- a/demo/Program.cs
+++ b/demo/Program.cs
@@ -29,6 +29,10 @@ namespace ConsoleClient
                 var networkDifficulty = CoinService.GetDifficulty();
                 Console.WriteLine("[OK]\n\n{0} Network Difficulty: {1}", CoinService.Parameters.CoinLongName, networkDifficulty.ToString("#,###", CultureInfo.InvariantCulture));
 
+                // Mining info
+                var miningInfo = CoinService.GetMiningInfo();
+                Console.WriteLine("[OK]\n\n{0} NetworkHashPS: {1}", CoinService.Parameters.CoinLongName, miningInfo.NetworkHashPS.ToString("#,###", CultureInfo.InvariantCulture));
+
                 //  My balance
                 var myBalance = CoinService.GetBalance();
                 Console.WriteLine("\nMy balance: {0} {1}", myBalance, CoinService.Parameters.CoinShortName);

--- a/src/BitcoinLib/Responses/GetMiningInfoResponse.cs
+++ b/src/BitcoinLib/Responses/GetMiningInfoResponse.cs
@@ -11,11 +11,11 @@ namespace BitcoinLib.Responses
         public double Difficulty { get; set; }
         public string Errors { get; set; }
         public int GenProcLimit { get; set; }
-        public long NetworkHashPS { get; set; }
+        public double NetworkHashPS { get; set; }
         public int PooledTx { get; set; }
         public bool Testnet { get; set; }
         public string Chain { get; set; }
         public bool Generate { get; set; }
-        public long HashesPerSec { get; set; }
+        public double HashesPerSec { get; set; }
     }
 }


### PR DESCRIPTION
The type of NetworkHashPS was long and this resulted in overflow
at block 591855. The value was 6.988e+19 and
int64.max ~= 9e18. This commit changes the type from long to
double. Local testing against my own node has been performed and
this change fixed the problem.

This closes issue #112 